### PR TITLE
Update semantics.md to improve consistency across example sections

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -21,7 +21,7 @@ _:a                           :b         "4"^^xsd:integer .
 ```
 and 
 ```
-_:a                           :c         "4"^^xsd:integer .
+_:a                           :c         "4"^^xsd:int .
 ```
 
 


### PR DESCRIPTION
Keep the use of xsd:int for the forth variant consistent across different examples