### PR TITLE
Update rdf-terminology.md from semi-transparent to semi-opaque

### DIFF
--- a/docs/rdf-terminology.md
+++ b/docs/rdf-terminology.md
@@ -139,6 +139,6 @@
 
 * [Opaque semantics](/docs/semantics.md#opaque-semantics) – Any semantics for quoted triples where the syntactic form of the arguments to quoted triples is important.
 
-* [Semi-transparent semantics](/docs/semantics.md#semi-transparent-semantics) – Any semantics for quoted triples where the syntactic form of some, but not all, kinds of arguments to quoted triples is important _usually excepting blank nodes so that only their meaning (and not their syntactic form) is important_.
+* [Semi-opaque semantics](/docs/semantics.md#semi-opaque-semantics) – Any semantics for quoted triples where the syntactic form of some, but not all, kinds of arguments to quoted triples is important _usually excepting blank nodes so that only their meaning (and not their syntactic form) is important_.
 
 * [Transparent semantics](/docs/semantics.md#transparent-semantics) – Any semantics for quoted triples where only the meaning of the arguments to quoted triples is important.


### PR DESCRIPTION
2 reasons to use semi-opaque instead of semi-transparent:

1) the term semi-opaque is shorter than semi-transparent and therefore more economical to utter. If there is no other reason for which variant to chose then this should make the difference.

2) more seriously, the fact that some terms are treated as opaque is what differentiates the semi-transparent/opaque semantics from the standard RDF semantics (which is fully transparent). IMHO emphasizing what is different instead of what is the same improves understanding.