### PR TITLE
Adds a SPARQL-related row to the 'seeking consensus' table

### DIFF
--- a/docs/seeking-consensus-2024-01.html
+++ b/docs/seeking-consensus-2024-01.html
@@ -85,7 +85,7 @@
 
 <p>This document is written in markdown for easy editing and quick
 preview in GitHub, but a <a
-href="https://htmlpreview.github.io/?https://github.com/w3c/rdf-star-wg/blob/main/docs/seeking-consensus-2024-01.md.md">better
+href="https://htmlpreview.github.io/?https://github.com/w3c/rdf-star-wg/blob/main/docs/seeking-consensus-2024-01.html">better
 rendering</a> (as a table) is available. It is generated with the
 following command line:</p>
 <div class="sourceCode" id="cb1"><pre
@@ -130,6 +130,16 @@ href="https://github.com/w3c/rdf-star-wg/blob/main/docs/rdfn-semantics.md">https
 ]</code></pre></li>
 <li><pre><code>:e rdf:nameOf &lt;&lt;(:s :p :o)&gt;&gt; .</code></pre></li>
 <li><pre><code>:e | :s :p :o .</code></pre></li>
+<li><hr />
+<p><code>SELECT (COUNT(*) AS ?c) { ?s ?p ?o }</code><br/>over
+<code>&lt;&lt;:e | :s :p :o&gt;&gt; :pp :oo .</code><br/>results in</p>
+<hr /></li>
+<li><p>4 (or 5 if <code>:e rdf:type rdf:Statement</code> is in the
+result of the expansion as well)</p></li>
+<li><p>5 (or 6 if <code>:e rdf:type rdf:Statement</code> is in the
+result of the expansion as well)</p></li>
+<li><p>2</p></li>
+<li><p>1?</p></li>
 <li><hr />
 <p>Abstract syntax</p>
 <hr /></li>

--- a/docs/seeking-consensus-2024-01.md
+++ b/docs/seeking-consensus-2024-01.md
@@ -58,6 +58,16 @@ pandoc seeking-consensus-2024-01.md -f gfm -o seeking-consensus-2024-01.html -s 
   ```
 
 
+-********************
+  `SELECT (COUNT(*) AS ?c) { ?s ?p ?o }` over `<<:e | :s :p :o>> :pp :oo .` results in
+  ********************
+
+- 4 (or 5 if `:e rdf:type rdf:Statement` is in the result of the expansion as well)
+- 5 (or 6 if `:e rdf:type rdf:Statement` is in the result of the expansion as well)
+- 2
+- 1?
+
+
 - ********************
   Abstract syntax
   ********************

--- a/docs/seeking-consensus-2024-01.md
+++ b/docs/seeking-consensus-2024-01.md
@@ -58,8 +58,8 @@ pandoc seeking-consensus-2024-01.md -f gfm -o seeking-consensus-2024-01.html -s 
   ```
 
 
--********************
-  `SELECT (COUNT(*) AS ?c) { ?s ?p ?o }` over `<<:e | :s :p :o>> :pp :oo .` results in
+- ********************
+  `SELECT (COUNT(*) AS ?c) { ?s ?p ?o }`<br/>over `<<:e | :s :p :o>> :pp :oo .`<br/>results in
   ********************
 
 - 4 (or 5 if `:e rdf:type rdf:Statement` is in the result of the expansion as well)


### PR DESCRIPTION
This PR extends @pchampin's "seeking consensus" table with a row that demonstrates the SPARQL-related implications of each of the approaches (as per my interpretation of the approaches).

(Sorry, I don't have the `pandoc` tool and, thus, could not generate the HTML version.)