### PR TITLE
Update for "triple-terms / descriptors"

### DIFF
--- a/docs/seeking-consensus-2024-01.html
+++ b/docs/seeking-consensus-2024-01.html
@@ -148,7 +148,7 @@ object    := iri | bnode | literal</code></pre></li>
 <li><p>add new kind of term:</p>
 <pre><code>graph       := triple*
 triple      := subject predicate object
-subject     := iri | bnode | TRIPLE-TERM
+subject     := iri | bnode
 predicate   := iri
 object      := iri | bnode | literal
                | TRIPLE-TERM

--- a/docs/seeking-consensus-2024-01.md
+++ b/docs/seeking-consensus-2024-01.md
@@ -82,7 +82,7 @@ pandoc seeking-consensus-2024-01.md -f gfm -o seeking-consensus-2024-01.html -s 
   ```
   graph       := triple*
   triple      := subject predicate object
-  subject     := iri | bnode | TRIPLE-TERM
+  subject     := iri | bnode
   predicate   := iri
   object      := iri | bnode | literal
                  | TRIPLE-TERM


### PR DESCRIPTION
This PR updates the "Atomic Reification" summary to reflect the updates document.

The triple-term/descriptor is only in the object position of a triple.
