### PR TITLE
fixes the definition of 'triple term' in constraints.md

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -19,6 +19,7 @@ The definitions in this document consider a version of the abstract data model o
 * If *s* is an IRI or a blank node, *p* is an IRI, and *o* is an IRI, a blank node, or a literal, then (*s*, *p*, *o*) is a triple term.
 * If *s* is an IRI or a blank node, *p* is an IRI, and *o* is a triple term, then (*s*, *p*, *o*) is a triple term.
 * If *s* is a triple term, *p* is an IRI, and *o* is an IRI, a blank node, or a literal, then (*s*, *p*, *o*) is a triple term.
+* If *s* is a triple term, *p* is an IRI, and *o* is a triple term, then (*s*, *p*, *o*) is a triple term.
 
 **Note:** While, syntactically, the notion of an RDF triple and the notion of a triple term are the same, they represent different concepts. RDF triples are the members of RDF graphs, whereas triple terms can be used as components of RDF triples.
 


### PR DESCRIPTION
In the definition of 'triple term' in my document from yesterday ([./docs/constraints.md](https://github.com/w3c/rdf-star-wg/blob/main/docs/constraints.md)), I forgot to cover the case of triple terms that contain other triple terms as both their subject and their object, as pointed out by @TallTed in https://github.com/w3c/rdf-star-wg/pull/117#discussion_r1576489248

This PR fixes this mistake.